### PR TITLE
Include <stdint.h> on every platform

### DIFF
--- a/platform.h
+++ b/platform.h
@@ -13,10 +13,10 @@
 #include <setjmp.h>
 #include <math.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 /* host platform includes */
 #ifdef UNIX_HOST
-# include <stdint.h>
 # include <unistd.h>
 #elif defined(WIN32) /*(predefined on MSVC)*/
 #else


### PR DESCRIPTION
Required to build with Visual Studio's v143 build tools.